### PR TITLE
URL encode the artist's name in DuckDuckGo request

### DIFF
--- a/src/rym.tsx
+++ b/src/rym.tsx
@@ -16,7 +16,7 @@ interface Song {
 
 async function getArtistPage(song: Song) {
   // use duckduckgo to find the artist page since it's more accurate than rym's search bar
-  const url = `https://duckduckgo.com/?q=%5Csite%3Arateyourmusic.com ${song.artist}`;
+  const url = `https://duckduckgo.com/?q=%5Csite%3Arateyourmusic.com%20${encodeURIComponent(song.artist)}`;
   const res = await fetch(url);
 
   // parse body to get redirect url


### PR DESCRIPTION
The extension works perfectly on Windows, but doesn't do anything on my Mac. I assume that, for some reason, Spotify/CEF/whatever is more stringent about spaces in HTTP requests (the error I'm getting is `http_error_invalid_url`). This patch URL encodes the artist in the DuckDuckGo request.
